### PR TITLE
Add selectionless toggle

### DIFF
--- a/RevolveSectionToggle.FCMacro
+++ b/RevolveSectionToggle.FCMacro
@@ -1,16 +1,44 @@
+# Macro by Mark1D
+# Toggle between half and full rotation, with both
+# plus and minus 180 degrees since sometimes your camera is on the bottom
+
 # -*- coding: utf-8 -*-
 import FreeCAD
 
+# Filter to say if the part is revolutionary
+def isRevolve(part):
+    return part.TypeId == 'Part::Revolution'
+
+# Flips between three different revolve angles
+def toggleAngle(part):
+    if part.Angle:
+        if part.Angle == 360.0:
+            part.Angle = -180.0
+        elif part.Angle == -180.0:
+            part.Angle = 180.0
+        else:
+            part.Angle = 360.0
+        return part.Angle
+    return 360.0
+
+def setAngle(part, angle):
+    if part.Angle:
+        part.Angle = angle
+
+def toggleAngleOfObjectList(list):
+    angleToSetOtherObjectsTo = 0;
+    for obj in filter(isRevolve, list):
+        # App.Console.PrintMessage("Part: "+obj.Label+", "+obj.FullName+"\n")
+        if angleToSetOtherObjectsTo == 0:
+            angleToSetOtherObjectsTo = toggleAngle(obj)
+        else:
+            setAngle(obj, angleToSetOtherObjectsTo)
+
 # Find the selected objects
 if FreeCADGui.Selection.getSelection():
-    for obj in FreeCADGui.Selection.getSelection():
-        # If the objects can revolve:
-        if obj.Angle:
-            # Toggle between half and full rotation
-            if obj.Angle == 360.00:
-                obj.Angle = -180.000
-            elif obj.Angle == -180.00:
-                obj.Angle = 180.000
-            else:
-                obj.Angle = 360.00
+    toggleAngleOfObjectList(FreeCADGui.Selection.getSelection())
+# or toggle all the objects
+else:
+    toggleAngleOfObjectList(App.ActiveDocument.Objects)
+
 # All done! Enjoy your slices


### PR DESCRIPTION
The macro now syncs the angle of all the toggled objects.
Running the macro with no selection toggles ALL revolves.